### PR TITLE
SCL-21: add structure + basic styling for task completion page

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,7 @@ import {
 } from 'firebase/auth';
 
 import TaskList from './components/tasks/TaskList';
+import TaskCompletion from './components/tasks/TaskCompletion';
 
 import { initializeApp } from 'firebase/app';
 import LoginPage from './pages/Login';
@@ -148,6 +149,7 @@ function App() {
           <Route path="/tasks/manhattan" element={<TaskList />}/>
           <Route path="/tasks/brooklyn" element={<TaskList />}/>
           <Route path="/tasks/queens" element={<TaskList />}/>
+          <Route path="/taskcompletion" element={<TaskCompletion />}/>
         </Routes>
       </BrowserRouter>
   </div>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -149,7 +149,7 @@ function App() {
           <Route path="/tasks/manhattan" element={<TaskList />}/>
           <Route path="/tasks/brooklyn" element={<TaskList />}/>
           <Route path="/tasks/queens" element={<TaskList />}/>
-          <Route path="/taskcompletion" element={<TaskCompletion />}/>
+          <Route path="/task-completion" element={<TaskCompletion />}/>
         </Routes>
       </BrowserRouter>
   </div>

--- a/app/src/components/tasks/TaskCompletion.tsx
+++ b/app/src/components/tasks/TaskCompletion.tsx
@@ -1,0 +1,111 @@
+import styled from "styled-components";
+import { useState } from 'react';
+import dummyTask from './dummyTask.json'
+
+
+export const TaskCompletionWrapper = styled.div`
+  text-align: left;
+  margin: 0 100px;
+`
+
+export const ChecklistItem = styled.div`
+  display: flex;
+  font-weight: 700;
+  font-size: 12px;
+  color: #343434;
+`
+
+export const HeaderText = styled.h1`
+  font-size: 14px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: #A8192E;
+`
+
+export const HeaderDescription = styled.p`
+  font-size: 14px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: #A8192E;
+`
+
+export const TaskHeader = styled.p`
+  margin-top: 0;
+`
+export const TaskDescription = styled.p``
+
+
+export const Checkbox = styled.input`
+
+`
+
+export const FileInputLabel = styled.label`
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 142px;
+  cursor: pointer;
+  color: #A8192E;
+  background: rgba(221, 103, 138, 0.2);
+  border: 1px solid #DD678A;
+  border-radius: 6px;
+  text-align: center;
+`
+
+export const FileInput = styled.input`
+  opacity: 0;
+  width: 0.1px;
+  height: 0.1px;
+  position: absolute;
+`
+
+export const SubmitButton = styled.button`
+  // TODO: if no image, show disabled button color: #8B8B8B;
+  background: #343434;
+  border-radius: 50px;
+  width: 100%;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: white;
+  font-weight: 700;
+`
+
+
+export default function TaskCompletion() {
+
+  const [imageFile, setImageFile] = useState('');
+
+  const onImageChange = (event: any) => {
+    if (event.target.files && event.target.files[0]) {
+      setImageFile(URL.createObjectURL(event.target.files[0]));
+    }
+  }
+
+  return (
+    <TaskCompletionWrapper>
+      {/* TODO: add cancel button */}
+      <div className='header'>
+        <HeaderText>Manhattan</HeaderText>
+        <HeaderDescription>Upload a photo of the completed activity</HeaderDescription>
+      </div>
+      <ChecklistItem>
+        <div>
+          <TaskHeader>{dummyTask.header}</TaskHeader>
+          <TaskDescription>{dummyTask.description}</TaskDescription>
+        </div>
+        <div>
+          <Checkbox type="checkbox" className='checkbox' />
+        </div>
+      </ChecklistItem>
+
+      {imageFile === "" ? (<div className="file-input">
+        <FileInput type="file" id="file" onChange={onImageChange} accept="image/*" />
+        <FileInputLabel htmlFor="file">Tap to upload a picture of your completed task</FileInputLabel>
+      </div>) :
+        <img alt="preview image" src={imageFile} />}
+      <SubmitButton>upload picture</SubmitButton>
+
+    </TaskCompletionWrapper>
+  );
+}

--- a/app/src/components/tasks/dummyTask.json
+++ b/app/src/components/tasks/dummyTask.json
@@ -1,0 +1,4 @@
+{
+    "header": "Grab a caffeinated drink at Dreamers Coffee House (54W Henry St)!",
+    "description": "Say hello to Daniel and Sandy, the two owners who built Dreamers Coffee House as a casual spot for locals and newcomers alike to mingle. They find joy in providing a space for the community to come together over coffee."
+}


### PR DESCRIPTION
Adds structure + basic styling for task completion page. Follow-up PR to flesh out styling + build confirmation modal to come. 

- Add new route `/taskcompletion`
- Add basic styling + dummy data for task completion page
- Add HTML file picker and basic image file upload

<img width="839" alt="image" src="https://user-images.githubusercontent.com/17485540/231900093-f8f57f00-ec2c-47ce-bddb-89b933c5be64.png">
<img width="795" alt="image" src="https://user-images.githubusercontent.com/17485540/231900141-c9f18a9f-60ae-4866-9fb2-6a53e6ad9037.png">
