### PR TITLE
Make sure setTasks is run when the component renders

### DIFF
--- a/app/src/components/tasks/TaskList.tsx
+++ b/app/src/components/tasks/TaskList.tsx
@@ -44,10 +44,15 @@ export default function TaskList(props: TaskListProps) {
   const airtableService = new AirTableService();
   const [completedTaskIds, setCompletedTaskIds] = React.useState<String[]>([]);
 
+  async function getTasks() {
+      setTasks(await airtableService.getTasks(borough));
+  }
+
   useEffect(() => {
-      async function getTasks() {
-          setTasks(await airtableService.getTasks(borough));
-      }
+      getTasks();
+  });
+
+  useEffect(() => {
       async function getCompletedTasks() {
         const completedTasks = await firebaseService.getTasksByBorough(userId!, borough!);
         setCompletedTaskIds(Object.keys(completedTasks));


### PR DESCRIPTION
Adds `setTasks()` call to a `useEffect()` so it renders when the `TaskList` component renders. Previously this was not happening so if a user refreshed while on a TaskList page there was no task data