### PR TITLE
Adjust raffle list header to display correctly if no raffle entered

### DIFF
--- a/app/src/components/raffle/RaffleHeader.tsx
+++ b/app/src/components/raffle/RaffleHeader.tsx
@@ -50,13 +50,13 @@ const GiveawaysText = styled.div`
 
 type RaffleHeaderProps = {
     availableTickets: number;
-    enteredTickets?: number;
+    enteredTickets: number;
 }
 
 export default function RaffleHeader(props: RaffleHeaderProps) {
     const { enteredTickets, availableTickets } = props;
     let topElement;
-    if (enteredTickets) {
+    if (enteredTickets >= 0) {
         topElement = <EnteredTicketsText><span>MY ENTERED RAFFLE TICKETS</span><span>{enteredTickets}</span></EnteredTicketsText>
     } else {
         topElement = <GiveawaysText>Giveaways</GiveawaysText>

--- a/app/src/pages/RaffleListView.tsx
+++ b/app/src/pages/RaffleListView.tsx
@@ -59,7 +59,7 @@ export default function RaffleListView(props: RaffleViewProps) {
                 selectedGiveaway ? (
                 <>
                     <CancelButton onClick={() => setSelectedGiveaway(null)}/>
-                    <RaffleHeader availableTickets={availableTickets} />
+                    <RaffleHeader availableTickets={availableTickets} enteredTickets={-1} />
                     <RaffleEntry
                         user={user}
                         availableTickets={availableTickets}


### PR DESCRIPTION
- Adjusted raffle list header to display correctly if no raffle entered (previously displayed "giveaways" twice in the raffle list view if enteredTickets = 0)
<img width="907" alt="Screen Shot 2023-04-30 at 9 02 03 PM" src="https://user-images.githubusercontent.com/44349752/235386279-66c22c7d-71a4-48c3-978d-5b59fe89c8dd.png">
