### PR TITLE
[SCL-67] Feature toggle app for raffle shutdown

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,7 +14,6 @@ import {
 
 import Login from "./pages/Login";
 import RaffleListView from "./pages/RaffleListView";
-import RaffleEntry from "./components/raffle/RaffleEntry";
 import TaskList from "./components/tasks/TaskList";
 
 import { initializeApp } from "firebase/app";

--- a/app/src/components/home/ticketsCounter.tsx
+++ b/app/src/components/home/ticketsCounter.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { LabelMedium, THEME_COLORS, PrimaryButton } from "../theme";
 import TicketsDataProptype from "../../propTypes/ticketsData";
 import styled from "styled-components";
+import {FeatureFlags, isFeatureFlagOn} from "../../utils/featureFlags";
 
 const TicketsCounterContainer = styled.div`
   display: flex;
@@ -81,7 +82,7 @@ function TicketsCounter(props: Props) {
           </TicketData>
           <ButtonContainer>
             <PrimaryButton onClick={() => navigate("/raffles")}>
-              { !ticketsAvailable ? "View" : "Enter"} Raffles
+              { isFeatureFlagOn(FeatureFlags.RAFFLE_SHUTDOWN_MAY_22) || !ticketsAvailable ? "View" : "Enter"} Raffles
             </PrimaryButton>
           </ButtonContainer>
         </ContentContainer>

--- a/app/src/components/raffle/GiveAwaysDetail.tsx
+++ b/app/src/components/raffle/GiveAwaysDetail.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { BubbleLabel, LabelMedium, THEME_COLORS } from "../theme";
+import {FeatureFlags, isFeatureFlagOn} from "../../utils/featureFlags";
 
 const PageTitleText = styled.div`
     border-top: 1px solid #A8192E;
@@ -24,6 +25,11 @@ type GiveAwaysDetailProps = {
 export default function GiveAwaysDetail(props: GiveAwaysDetailProps) {
     const { numberOfEntries } = props;
 
+    let text = "For every completed activity, you'll earn one (1) raffle ticket. Each giveaway prize is worth a certain number of raffle tickets for one (1) raffle entry. Once you have enough tickets, enter them into the giveaway prize of your choice!";
+    if (isFeatureFlagOn(FeatureFlags.RAFFLE_SHUTDOWN_MAY_22)) {
+        text = "The giveaway has ended. Thanks for playing!"
+    }
+
     return (
     <div>
       <PageTitleText>
@@ -31,7 +37,7 @@ export default function GiveAwaysDetail(props: GiveAwaysDetailProps) {
         <BubbleLabel>{numberOfEntries} ENTRIES</BubbleLabel>
       </PageTitleText>
       <PageDescription>
-        <span>For every completed activity, you'll earn one (1) raffle ticket. Each giveaway prize is worth a certain number of raffle tickets for one (1) raffle entry. Once you have enough tickets, enter them into the giveaway prize of your choice!</span>
+        <span>{text}</span>
       </PageDescription>
     </div>
   );

--- a/app/src/components/raffle/GiveAwaysDetail.tsx
+++ b/app/src/components/raffle/GiveAwaysDetail.tsx
@@ -27,7 +27,7 @@ export default function GiveAwaysDetail(props: GiveAwaysDetailProps) {
 
     let text = "For every completed activity, you'll earn one (1) raffle ticket. Each giveaway prize is worth a certain number of raffle tickets for one (1) raffle entry. Once you have enough tickets, enter them into the giveaway prize of your choice!";
     if (isFeatureFlagOn(FeatureFlags.RAFFLE_SHUTDOWN_MAY_22)) {
-        text = "The giveaway has ended. Thanks for playing!"
+        text = "The giveaways have ended. Thanks for playing!"
     }
 
     return (

--- a/app/src/components/raffle/RafflePrize.tsx
+++ b/app/src/components/raffle/RafflePrize.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import {BubbleLabel} from "../theme";
 import {useEffect, useState} from "react";
 import {FirebaseService} from "../../Api";
+import {FeatureFlags, isFeatureFlagOn} from "../../utils/featureFlags";
 
 const RafflePrizeContainer = styled.div`
     margin: 0 auto 16px;
@@ -123,8 +124,12 @@ export default function RafflePrize(props: RaffleListProps) {
       getEntries();
   });
 
-  return(
-      <RafflePrizeContainer onClick={() => props.setSelectedGiveaway(props.prize)}>
+    function setSelectedGiveaway() {
+        if (!isFeatureFlagOn(FeatureFlags.RAFFLE_SHUTDOWN_MAY_22)) props.setSelectedGiveaway(props.prize);
+    }
+
+    return(
+      <RafflePrizeContainer onClick={() => setSelectedGiveaway()}>
         <PrizeDescriptionContainer>
             <TicketContainer>
                 <TicketIcon ticketsRequired={ticketsRequired} availableTickets={availableTickets}></TicketIcon>

--- a/app/src/components/tasks/TaskList.tsx
+++ b/app/src/components/tasks/TaskList.tsx
@@ -12,6 +12,7 @@ import TaskListHeader from "./TaskListHeader";
 import {AirTableService, FirebaseService, Task} from "../../Api";
 import { PageContainer } from "../theme";
 import GooglyEyeLoader from "../shared/GooglyEyeLoader";
+import {FeatureFlags, isFeatureFlagOn} from "../../utils/featureFlags";
 
 export type TaskInfo = {
     title: string;
@@ -67,7 +68,9 @@ export default function TaskList(props: TaskListProps) {
 
   let navigate = useNavigate();
 
-  const onTaskClick = (task: TaskInfo) => setSelectedTask(task);
+  const onTaskClick = (task: TaskInfo) => {
+      if (!isFeatureFlagOn(FeatureFlags.RAFFLE_SHUTDOWN_MAY_22)) setSelectedTask(task);
+  }
 
   return (
       <>
@@ -75,7 +78,10 @@ export default function TaskList(props: TaskListProps) {
               <GooglyEyeLoader></GooglyEyeLoader>
           ) : (
               <PageContainer>
-                  {selectedTask?.title && selectedTask?.description ? (
+                  {
+                      selectedTask?.title &&
+                      selectedTask?.description &&
+                      !isFeatureFlagOn(FeatureFlags.RAFFLE_SHUTDOWN_MAY_22) ? (
                       <>
                           <CancelButton onClick={() => setSelectedTask(null)} />
                           <TaskCompletionHeader borough={borough!} />

--- a/app/src/pages/RaffleListView.tsx
+++ b/app/src/pages/RaffleListView.tsx
@@ -12,6 +12,7 @@ import RaffleList, { RafflePrizeData } from "../components/raffle/RaffleList";
 import RaffleEntry from "../components/raffle/RaffleEntry";
 import EntryConfirmationModal from "../components/raffle/EntryConfirmationModal";
 import { fetchEnteredRaffleTickets } from "../utils/user";
+import {FeatureFlags, isFeatureFlagOn} from "../utils/featureFlags";
 
 type RaffleViewProps = {
     prizeData: RafflePrizeData[];
@@ -56,7 +57,7 @@ export default function RaffleListView(props: RaffleViewProps) {
         <>
         <PageContainer>
             {
-                selectedGiveaway ? (
+                selectedGiveaway && !isFeatureFlagOn(FeatureFlags.RAFFLE_SHUTDOWN_MAY_22) ? (
                 <>
                     <CancelButton onClick={() => setSelectedGiveaway(null)}/>
                     <RaffleHeader availableTickets={availableTickets} enteredTickets={-1} />

--- a/app/src/utils/featureFlags.tsx
+++ b/app/src/utils/featureFlags.tsx
@@ -1,0 +1,8 @@
+export function isFeatureFlagOn(featureFlag: string) {
+    console.log(import.meta.env[featureFlag]);
+    return import.meta.env[featureFlag] === 'true';
+}
+
+export const FeatureFlags = {
+    RAFFLE_SHUTDOWN_MAY_22: 'VITE_REACT_APP_RAFFLE_SHUTDOWN_MAY_22',
+}

--- a/app/src/utils/featureFlags.tsx
+++ b/app/src/utils/featureFlags.tsx
@@ -1,5 +1,4 @@
 export function isFeatureFlagOn(featureFlag: string) {
-    console.log(import.meta.env[featureFlag]);
     return import.meta.env[featureFlag] === 'true';
 }
 


### PR DESCRIPTION
* Adds method to check if feature flag is toggled on
* Adds `RAFFLE_SHUTDOWN_MAY_22` feature toggle
* If the toggle is on:
  * User cannot click on tasks in TaskList page
  * User cannot click on raffles in RaffleList page
  * `GiveAwaysDetail` text changes to "The giveaway has ended. Thanks for playing!"
  * On the home page, the ENTER RAFFLES button text changes to VIEW RAFFLES

Tested app with toggle off and on and it works as expected

Screen recording:
https://user-images.githubusercontent.com/16674015/236958413-5c52c4bb-406c-4689-9868-0c6e4481b8ab.mov

