### PR TITLE
SCL-71: File Upload Limits and Filetype Limiting

### DIFF
--- a/app/src/components/task-completion/TaskCompletionBody.tsx
+++ b/app/src/components/task-completion/TaskCompletionBody.tsx
@@ -57,6 +57,7 @@ export default function TaskCompletion(props: TaskCompletionProps) {
     const [image, setImage] = useState<File | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [errorHasOccurred, setErrorHasOccurred] = useState(false);
+    const [invalidImageMessage, setInvalidImageMessage] = useState("");
     const [isPopupActive, setIsPopupActive] = useState(false);
     const [hasImageBeenUploaded, setHasImageBeenUploaded] = useState<boolean>(false);
 
@@ -141,9 +142,10 @@ export default function TaskCompletion(props: TaskCompletionProps) {
                     isChecked={imageFileSrc !== ""}
                 />
                 <UploadWrapper>
-                    <TaskUpload imageFileSrc={imageFileSrc} setImageFileSrc={setImageFileSrc} setImage={setImage} />
+                    <TaskUpload imageFileSrc={imageFileSrc} setImageFileSrc={setImageFileSrc} setImage={setImage} setInvalidImageMessage={setInvalidImageMessage} />
                     {errorHasOccurred &&
                         <ErrorMessage>{' Sorry! We had trouble uploading that image. Try again?'}</ErrorMessage>}
+                        <ErrorMessage>{invalidImageMessage}</ErrorMessage>
                     <UploadButton
                         disabled={!hasImageBeenUploaded}
                         isDisabled={!hasImageBeenUploaded}

--- a/app/src/components/task-completion/TaskUpload.tsx
+++ b/app/src/components/task-completion/TaskUpload.tsx
@@ -67,15 +67,27 @@ type TaskUploadProps = {
   imageFileSrc: any;
   setImage: React.Dispatch<React.SetStateAction<any>>;
   setImageFileSrc: React.Dispatch<React.SetStateAction<any>>;
+  setInvalidImageMessage: React.Dispatch<React.SetStateAction<any>>;
 }
 
 export default function TaskUpload(props: TaskUploadProps) {
-  const { imageFileSrc, setImage, setImageFileSrc } = props;
+  const { imageFileSrc, setImage, setImageFileSrc, setInvalidImageMessage } = props;
 
   const onImageChange = (event: any) => {
+    console.log('event.target.files[0]',  event.target.files[0])
     if (event.target.files && event.target.files[0]) {
+      const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png']
+      if (!allowedTypes.includes(event.target.files[0].type)) {
+        setInvalidImageMessage('Please upload a valid image file!')
+        return;
+      };
+      if (event.target.files[0].size > 1000000) {
+        setInvalidImageMessage('File is too large! Please upload a smaller image.')
+        return;
+      };
       setImage(event.target.files[0]);
       setImageFileSrc(URL.createObjectURL(event.target.files[0]));
+      setInvalidImageMessage('');
     }
   };
 

--- a/app/src/components/task-completion/TaskUpload.tsx
+++ b/app/src/components/task-completion/TaskUpload.tsx
@@ -76,12 +76,12 @@ export default function TaskUpload(props: TaskUploadProps) {
   const onImageChange = (event: any) => {
     console.log('event.target.files[0]',  event.target.files[0])
     if (event.target.files && event.target.files[0]) {
-      const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png']
+      const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/heic']
       if (!allowedTypes.includes(event.target.files[0].type)) {
         setInvalidImageMessage('Please upload a valid image file!')
         return;
       };
-      if (event.target.files[0].size > 1000000) {
+      if (event.target.files[0].size > 10000000 ) {
         setInvalidImageMessage('File is too large! Please upload a smaller image.')
         return;
       };
@@ -96,7 +96,7 @@ export default function TaskUpload(props: TaskUploadProps) {
       <FileInputWrapper>
         {imageFileSrc === "" ? (
           <>
-            <FileInput type="file" id="file" onChange={onImageChange} accept="image/*" />
+            <FileInput type="file" id="file" onChange={onImageChange} accept="image/*, .heic" />
             <FileInputLabel htmlFor="file">
               <UploadIcon />
               Tap to upload a picture of your completed activity
@@ -105,7 +105,7 @@ export default function TaskUpload(props: TaskUploadProps) {
           </>
         ) :
           <div>
-            <ReplaceFileInput type="file" id="file" onChange={onImageChange} accept="image/*" />
+            <ReplaceFileInput type="file" id="file" onChange={onImageChange} accept="image/*, .heic" />
             <ReplaceFileInputLabel htmlFor="file">
               <div style={{ position: 'relative' }}><UserUploadedImg alt="preview image" src={imageFileSrc} />
                 <ReplaceTag>Tap to replace</ReplaceTag>

--- a/app/src/components/task-completion/TaskUpload.tsx
+++ b/app/src/components/task-completion/TaskUpload.tsx
@@ -74,7 +74,6 @@ export default function TaskUpload(props: TaskUploadProps) {
   const { imageFileSrc, setImage, setImageFileSrc, setInvalidImageMessage } = props;
 
   const onImageChange = (event: any) => {
-    console.log('event.target.files[0]',  event.target.files[0])
     if (event.target.files && event.target.files[0]) {
       const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/heic']
       if (!allowedTypes.includes(event.target.files[0].type)) {


### PR DESCRIPTION
- add validation for large file uploads (> 1MB)
- add validation for invalid image file (couldn't test mobile on web locally since on web, it was already not allowed but hopefully this now works too on mobile 😅)

<img width="385" alt="Screen Shot 2023-05-10 at 10 17 34 PM" src="https://github.com/sendchinatownlove/apham-ecaao/assets/60532744/a8643660-e2ae-48df-8af9-f94034bc4a62">
